### PR TITLE
Fix: Change url when setup is completed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .deploy
 .fission.yaml
+.vscode/
 build
 elm-stuff
 node_modules


### PR DESCRIPTION
## Summary

Fixes the infinite loading screen when opening drive when authenticated and going to `drive.runfission.net` or `localhost:8000`.

Also abstracted some resulting code duplication.

## Closing issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #72

## After Merge
* [ ] Does this change require a release to be made? Is so please create and deploy the release
