### PR TITLE
Fix tap events on mobile not parsed by decoder

### DIFF
--- a/src/Library/Html/Events/Ext.elm
+++ b/src/Library/Html/Events/Ext.elm
@@ -10,11 +10,12 @@ onTap msg =
     Html.Events.on "tap"
         (Decode.andThen
             (\button ->
-                if button /= 2 then
-                    Decode.succeed msg
+                case button of
+                    Just 2 ->
+                        Decode.fail "Ignore right click"
 
-                else
-                    Decode.fail "Ignore right click"
+                    _ ->
+                        Decode.succeed msg
             )
-            (Decode.at [ "originalEvent", "button" ] Decode.int)
+            (Decode.maybe (Decode.at [ "originalEvent", "button" ] Decode.int))
         )


### PR DESCRIPTION
## Summary

Using fission drive on mobile didn't work for me.
Tapping on anything just didn't do anything.

After debugging, I noticed that the events were ignored, because the decoder expected there to be a `button` property on the event, which doesn't exist on my mobile, apparently.

## Test plan (required)

This should absolutely not break anything, the diff is really small.

The only regression I can think of is that right-clicks might now trigger `tap` events again, but that doesn't happen for me, but that might be something you could test.

Testing fission drive on mobile is _really_ sophisticated. For me it involves android device debugging and running an nginx https proxy with a selfsigned certificate. How do you test on mobile?
If you want to, I think it'd make sense to write a small guide on how to set all of that up.

(I've been personally very motivated by having an encrypted, shared image folder between my laptop and mobile devices, so that's why I've poured a little time into debugging this.)

## The bigger picture

I am a little unhappy about how elm just ignores events when the decoders fail, without an error message.
That's why I usually like to always parse events to `Json.Value` and parse them later, and in case of `Err`, I write the decoding error to the console with a dedicated message. It's maybe 10 lines of overhead and pays off in the long run I think. What do you think about that?