### PR TITLE
Plaintext editor adjustments

### DIFF
--- a/src/Application/Drive/Item.elm
+++ b/src/Application/Drive/Item.elm
@@ -21,6 +21,7 @@ type Kind
     | Image
     | Text
     | Video
+    | RichText
       --
     | Other
 
@@ -63,7 +64,11 @@ imageFileExtensions =
 
 
 textFileExtensions =
-    [ "doc", "json", "pdf", "txt", "toml", "yaml" ]
+    [ "json", "txt", "toml", "yaml" ]
+
+
+richtextFileExtensions =
+    [ "doc", "pdf" ]
 
 
 videoFileExtensions =
@@ -95,6 +100,9 @@ canRenderKind kind =
 
         Video ->
             True
+
+        RichText ->
+            False
 
         --
         Other ->
@@ -131,6 +139,9 @@ fromFileSystem { cid, name, path, posixTime, size, typ } =
 
                     else if List.member nameProps.extension textFileExtensions then
                         Text
+
+                    else if List.member nameProps.extension richtextFileExtensions then
+                        RichText
 
                     else if List.member nameProps.extension videoFileExtensions then
                         Video
@@ -255,6 +266,9 @@ kindIcon kind =
         Video ->
             FeatherIcons.video
 
+        RichText ->
+            FeatherIcons.fileText
+
         --
         Other ->
             FeatherIcons.file
@@ -281,6 +295,9 @@ kindName kind =
 
         Video ->
             "Video"
+
+        RichText ->
+            "Rich Text"
 
         --
         Other ->

--- a/src/Application/Drive/Sidebar.elm
+++ b/src/Application/Drive/Sidebar.elm
@@ -24,6 +24,7 @@ type Mode
 type alias EditorModel =
     { text : String
     , originalText : String
+    , isSaving : Bool
     }
 
 

--- a/src/Application/Drive/State/Sidebar.elm
+++ b/src/Application/Drive/State/Sidebar.elm
@@ -11,7 +11,10 @@ update : Sidebar.Msg -> Sidebar.Model -> Manager
 update msg sidebar model =
     case ( sidebar.mode, msg ) of
         ( Sidebar.EditPlaintext (Just editorModel), Sidebar.PlaintextEditorInput content ) ->
-            { editorModel | text = content }
+            { editorModel
+                | text = content
+                , isSaving = False
+            }
                 |> Just
                 |> Sidebar.EditPlaintext
                 |> (\newMode -> { sidebar | mode = newMode })
@@ -26,7 +29,10 @@ update msg sidebar model =
                     , text = editorModel.text
                     }
                     |> Return.return
-                        ({ editorModel | originalText = editorModel.text }
+                        ({ editorModel
+                            | originalText = editorModel.text
+                            , isSaving = True
+                         }
                             |> Just
                             |> Sidebar.EditPlaintext
                             |> (\newMode -> { sidebar | mode = newMode })

--- a/src/Application/Drive/View/Sidebar.elm
+++ b/src/Application/Drive/View/Sidebar.elm
@@ -318,6 +318,9 @@ editorFooterItems editor =
         , T.appearance_none
         , T.bg_purple_shade
         , T.font_semibold
+        , T.flex
+        , T.flex_row
+        , T.items_center
         , T.leading_normal
         , T.outline_none
         , T.px_4
@@ -338,7 +341,17 @@ editorFooterItems editor =
         , T.dark__disabled__bg_gray_200
         , T.disabled__text_gray_400
         ]
-        [ Html.text "Save" ]
+        [ Common.loadingAnimationWithAttributes
+            [ T.mr_2
+            , if editor.isSaving then
+                T.inline
+
+              else
+                T.hidden
+            ]
+            { size = S.iconSize }
+        , Html.text "Save"
+        ]
     , Html.button
         [ E.onClick CloseSidebar
         , T.outline_none

--- a/src/Application/Drive/View/Sidebar.elm
+++ b/src/Application/Drive/View/Sidebar.elm
@@ -297,11 +297,23 @@ editorHeaderItems model =
 editorFooterItems : Sidebar.EditorModel -> List (Html Msg)
 editorFooterItems editor =
     let
-        hasChanges =
-            editor.text /= editor.originalText
+        { isDisabled, title } =
+            if editor.text /= editor.originalText then
+                { isDisabled = False
+                , title = "Save changes"
+                }
+
+            else
+                { isDisabled = True
+                , title = "Changes are saved"
+                }
     in
     [ Html.button
         [ E.onClick (SidebarMsg Sidebar.PlaintextEditorSave)
+        , A.title title
+        , A.disabled isDisabled
+
+        --
         , T.antialiased
         , T.appearance_none
         , T.bg_purple_shade
@@ -320,6 +332,11 @@ editorFooterItems editor =
 
         --
         , T.focus__shadow_outline
+
+        --
+        , T.disabled__bg_gray_600
+        , T.dark__disabled__bg_gray_200
+        , T.disabled__text_gray_400
         ]
         [ Html.text "Save" ]
     , Html.button

--- a/src/Application/Drive/View/Sidebar.elm
+++ b/src/Application/Drive/View/Sidebar.elm
@@ -17,7 +17,7 @@ import Html.Events.Extra as E
 import Html.Events.Extra.Mouse as M
 import Html.Extra as Html exposing (nothing)
 import Html.Lazy
-import Json.Decode as D
+import Json.Decode as Decode
 import List.Extra as List
 import Maybe.Extra as Maybe
 import Radix exposing (..)
@@ -567,23 +567,23 @@ onCtrlS message =
     let
         ensureEquals value decoder =
             decoder
-                |> D.andThen
+                |> Decode.andThen
                     (\val ->
                         if val == value then
-                            D.succeed ()
+                            Decode.succeed ()
 
                         else
-                            D.fail "Unexpecated value"
+                            Decode.fail "Unexpecated value"
                     )
     in
     E.custom "keydown"
-        (D.map2
+        (Decode.map2
             (\_ _ ->
                 { message = message
                 , stopPropagation = True
                 , preventDefault = True
                 }
             )
-            (D.field "key" D.string |> ensureEquals "s")
-            (D.field "ctrlKey" D.bool |> ensureEquals True)
+            (Decode.field "key" Decode.string |> ensureEquals "s")
+            (Decode.field "ctrlKey" Decode.bool |> ensureEquals True)
         )

--- a/src/Application/Drive/View/Sidebar.elm
+++ b/src/Application/Drive/View/Sidebar.elm
@@ -17,6 +17,7 @@ import Html.Events.Extra as E
 import Html.Events.Extra.Mouse as M
 import Html.Extra as Html exposing (nothing)
 import Html.Lazy
+import Json.Decode as D
 import List.Extra as List
 import Maybe.Extra as Maybe
 import Radix exposing (..)
@@ -117,6 +118,7 @@ plaintextEditor maybeEditor sidebar model =
             Just editor ->
                 Html.textarea
                     [ E.onInput (SidebarMsg << Sidebar.PlaintextEditorInput)
+                    , onCtrlS (SidebarMsg Sidebar.PlaintextEditorSave)
 
                     --
                     , T.bg_transparent
@@ -554,3 +556,34 @@ detailsForSelection { showPreviewOverlay } sidebar model =
             |> Maybe.withDefault
                 nothing
         ]
+
+
+
+-- UTILITIES
+
+
+onCtrlS : msg -> Html.Attribute msg
+onCtrlS message =
+    let
+        ensureEquals value decoder =
+            decoder
+                |> D.andThen
+                    (\val ->
+                        if val == value then
+                            D.succeed ()
+
+                        else
+                            D.fail "Unexpecated value"
+                    )
+    in
+    E.custom "keydown"
+        (D.map2
+            (\_ _ ->
+                { message = message
+                , stopPropagation = True
+                , preventDefault = True
+                }
+            )
+            (D.field "key" D.string |> ensureEquals "s")
+            (D.field "ctrlKey" D.bool |> ensureEquals True)
+        )

--- a/src/Application/Drive/View/Sidebar.elm
+++ b/src/Application/Drive/View/Sidebar.elm
@@ -302,11 +302,13 @@ editorFooterItems editor =
     in
     [ if hasChanges then
         Html.button
-            [ T.antialiased
+            [ E.onClick (SidebarMsg Sidebar.PlaintextEditorSave)
+            , T.antialiased
             , T.appearance_none
             , T.bg_purple_shade
             , T.font_semibold
             , T.leading_normal
+            , T.outline_none
             , T.px_4
             , T.py_2
             , T.relative
@@ -316,7 +318,9 @@ editorFooterItems editor =
             , T.tracking_wider
             , T.transition_colors
             , T.uppercase
-            , E.onClick (SidebarMsg Sidebar.PlaintextEditorSave)
+
+            --
+            , T.focus__shadow_outline
             ]
             [ Html.text "Save" ]
 
@@ -324,13 +328,18 @@ editorFooterItems editor =
         nothing
     , if hasChanges then
         Html.button
-            [ T.px_4
+            [ E.onClick CloseSidebar
+            , T.outline_none
+            , T.px_4
             , T.py_2
+            , T.rounded
             , T.text_gray_400
             , T.text_tiny
             , T.tracking_wide
             , T.uppercase
-            , E.onClick CloseSidebar
+
+            --
+            , T.focus__shadow_outline
             ]
             [ Html.text "Cancel" ]
 

--- a/src/Application/Drive/View/Sidebar.elm
+++ b/src/Application/Drive/View/Sidebar.elm
@@ -166,9 +166,9 @@ plaintextEditor maybeEditor sidebar model =
             , T.flex_shrink_0
             , T.h_12
             , T.items_center
-            , T.justify_end
+            , T.justify_start
             , T.mt_px
-            , T.p_2
+            , T.py_2
             , T.relative
             , T.space_x_2
             ]
@@ -302,20 +302,6 @@ editorFooterItems editor =
     in
     [ if hasChanges then
         Html.button
-            [ T.px_4
-            , T.py_2
-            , T.text_gray_400
-            , T.text_tiny
-            , T.tracking_wide
-            , T.uppercase
-            , E.onClick CloseSidebar
-            ]
-            [ Html.text "Cancel" ]
-
-      else
-        nothing
-    , if hasChanges then
-        Html.button
             [ T.antialiased
             , T.appearance_none
             , T.bg_purple_shade
@@ -333,6 +319,20 @@ editorFooterItems editor =
             , E.onClick (SidebarMsg Sidebar.PlaintextEditorSave)
             ]
             [ Html.text "Save" ]
+
+      else
+        nothing
+    , if hasChanges then
+        Html.button
+            [ T.px_4
+            , T.py_2
+            , T.text_gray_400
+            , T.text_tiny
+            , T.tracking_wide
+            , T.uppercase
+            , E.onClick CloseSidebar
+            ]
+            [ Html.text "Cancel" ]
 
       else
         nothing

--- a/src/Application/Drive/View/Sidebar.elm
+++ b/src/Application/Drive/View/Sidebar.elm
@@ -345,17 +345,13 @@ editorFooterItems editor =
         ]
         [ Common.loadingAnimationWithAttributes
             [ T.mr_2
-            , T.flex
-            , T.items_center
-            , T.justify_center
-            , T.h_0
             , if editor.isSaving then
                 T.inline
 
               else
                 T.hidden
             ]
-            { size = S.iconSize }
+            { size = 18 }
         , Html.text "Save"
         ]
     , Html.button

--- a/src/Application/Drive/View/Sidebar.elm
+++ b/src/Application/Drive/View/Sidebar.elm
@@ -343,6 +343,10 @@ editorFooterItems editor =
         ]
         [ Common.loadingAnimationWithAttributes
             [ T.mr_2
+            , T.flex
+            , T.items_center
+            , T.justify_center
+            , T.h_0
             , if editor.isSaving then
                 T.inline
 

--- a/src/Application/Drive/View/Sidebar.elm
+++ b/src/Application/Drive/View/Sidebar.elm
@@ -163,10 +163,11 @@ plaintextEditor maybeEditor sidebar model =
                     ]
         , Html.div
             [ T.flex
+            , T.flex_row_reverse
             , T.flex_shrink_0
             , T.h_12
             , T.items_center
-            , T.justify_end
+            , T.justify_start
             , T.mt_px
             , T.p_2
             , T.relative
@@ -185,7 +186,7 @@ plaintextEditor maybeEditor sidebar model =
                     []
                 ]
                 (maybeEditor
-                    |> Maybe.map editorFooterItems
+                    |> Maybe.map (editorFooterItems >> List.reverse)
                     |> Maybe.withDefault []
                 )
             )

--- a/src/Application/Drive/View/Sidebar.elm
+++ b/src/Application/Drive/View/Sidebar.elm
@@ -300,51 +300,43 @@ editorFooterItems editor =
         hasChanges =
             editor.text /= editor.originalText
     in
-    [ if hasChanges then
-        Html.button
-            [ E.onClick (SidebarMsg Sidebar.PlaintextEditorSave)
-            , T.antialiased
-            , T.appearance_none
-            , T.bg_purple_shade
-            , T.font_semibold
-            , T.leading_normal
-            , T.outline_none
-            , T.px_4
-            , T.py_2
-            , T.relative
-            , T.rounded
-            , T.text_tiny
-            , T.text_white
-            , T.tracking_wider
-            , T.transition_colors
-            , T.uppercase
+    [ Html.button
+        [ E.onClick (SidebarMsg Sidebar.PlaintextEditorSave)
+        , T.antialiased
+        , T.appearance_none
+        , T.bg_purple_shade
+        , T.font_semibold
+        , T.leading_normal
+        , T.outline_none
+        , T.px_4
+        , T.py_2
+        , T.relative
+        , T.rounded
+        , T.text_tiny
+        , T.text_white
+        , T.tracking_wider
+        , T.transition_colors
+        , T.uppercase
 
-            --
-            , T.focus__shadow_outline
-            ]
-            [ Html.text "Save" ]
+        --
+        , T.focus__shadow_outline
+        ]
+        [ Html.text "Save" ]
+    , Html.button
+        [ E.onClick CloseSidebar
+        , T.outline_none
+        , T.px_4
+        , T.py_2
+        , T.rounded
+        , T.text_gray_400
+        , T.text_tiny
+        , T.tracking_wide
+        , T.uppercase
 
-      else
-        nothing
-    , if hasChanges then
-        Html.button
-            [ E.onClick CloseSidebar
-            , T.outline_none
-            , T.px_4
-            , T.py_2
-            , T.rounded
-            , T.text_gray_400
-            , T.text_tiny
-            , T.tracking_wide
-            , T.uppercase
-
-            --
-            , T.focus__shadow_outline
-            ]
-            [ Html.text "Cancel" ]
-
-      else
-        nothing
+        --
+        , T.focus__shadow_outline
+        ]
+        [ Html.text "Cancel" ]
     ]
 
 

--- a/src/Application/Drive/View/Sidebar.elm
+++ b/src/Application/Drive/View/Sidebar.elm
@@ -163,11 +163,10 @@ plaintextEditor maybeEditor sidebar model =
                     ]
         , Html.div
             [ T.flex
-            , T.flex_row_reverse
             , T.flex_shrink_0
             , T.h_12
             , T.items_center
-            , T.justify_start
+            , T.justify_end
             , T.mt_px
             , T.p_2
             , T.relative
@@ -186,7 +185,7 @@ plaintextEditor maybeEditor sidebar model =
                     []
                 ]
                 (maybeEditor
-                    |> Maybe.map (editorFooterItems >> List.reverse)
+                    |> Maybe.map editorFooterItems
                     |> Maybe.withDefault []
                 )
             )

--- a/src/Application/FileSystem/State.elm
+++ b/src/Application/FileSystem/State.elm
@@ -85,12 +85,15 @@ gotDirectoryList json model =
 
                     --
                     , sidebar =
-                        selectedPath
-                            |> Maybe.map
-                                (\path ->
-                                    { path = path
-                                    , mode = Sidebar.details
-                                    }
+                        sidebar
+                            |> Maybe.orElse
+                                (selectedPath
+                                    |> Maybe.map
+                                        (\path ->
+                                            { path = path
+                                            , mode = Sidebar.details
+                                            }
+                                        )
                                 )
                     , fileSystemCid = maybeRootCid
                     , fileSystemStatus = FileSystem.Ready

--- a/src/Application/FileSystem/State.elm
+++ b/src/Application/FileSystem/State.elm
@@ -82,20 +82,33 @@ gotDirectoryList json model =
                             Just sidebarModel ->
                                 case sidebarModel.mode of
                                     Sidebar.EditPlaintext (Just editorModel) ->
-                                        { editorModel
-                                            | isSaving = False
-                                            , originalText = editorModel.text
-                                        }
-                                            |> Just
-                                            |> Sidebar.EditPlaintext
-                                            |> (\newMode -> { sidebarModel | mode = newMode })
-                                            |> Just
+                                        let
+                                            editPath =
+                                                sidebarModel.path
+                                                    |> String.split "/"
+
+                                            editDirectory =
+                                                editPath
+                                                    |> List.take (List.length editPath - 1)
+                                        in
+                                        if pathSegments == editDirectory then
+                                            { editorModel
+                                                | isSaving = False
+                                                , originalText = editorModel.text
+                                            }
+                                                |> Just
+                                                |> Sidebar.EditPlaintext
+                                                |> (\newMode -> { sidebarModel | mode = newMode })
+                                                |> Just
+
+                                        else
+                                            Nothing
 
                                     _ ->
-                                        model.sidebar
+                                        Nothing
 
                             _ ->
-                                model.sidebar
+                                Nothing
                 in
                 { model
                     | directoryList =

--- a/src/Application/FileSystem/State.elm
+++ b/src/Application/FileSystem/State.elm
@@ -22,6 +22,8 @@ import Task
 -- 🐚
 
 
+{-| TODO This function is doing a lot. Can we break it up somehow?
+-}
 gotDirectoryList : Json.Value -> Manager
 gotDirectoryList json model =
     let
@@ -87,9 +89,21 @@ gotDirectoryList json model =
                                                 sidebarModel.path
                                                     |> String.split "/"
 
-                                            editDirectory =
+                                            editDirectoryWithPrivate =
                                                 editPath
                                                     |> List.take (List.length editPath - 1)
+
+                                            editDirectory =
+                                                case editDirectoryWithPrivate of
+                                                    first :: rest ->
+                                                        if first == "private" then
+                                                            rest
+
+                                                        else
+                                                            first :: rest
+
+                                                    other ->
+                                                        other
                                         in
                                         if pathSegments == editDirectory then
                                             { editorModel

--- a/src/Application/FileSystem/State.elm
+++ b/src/Application/FileSystem/State.elm
@@ -76,6 +76,26 @@ gotDirectoryList json model =
 
                             _ ->
                                 Nothing
+
+                    sidebar =
+                        case model.sidebar of
+                            Just sidebarModel ->
+                                case sidebarModel.mode of
+                                    Sidebar.EditPlaintext (Just editorModel) ->
+                                        { editorModel
+                                            | isSaving = False
+                                            , originalText = editorModel.text
+                                        }
+                                            |> Just
+                                            |> Sidebar.EditPlaintext
+                                            |> (\newMode -> { sidebarModel | mode = newMode })
+                                            |> Just
+
+                                    _ ->
+                                        model.sidebar
+
+                            _ ->
+                                model.sidebar
                 in
                 { model
                     | directoryList =
@@ -118,6 +138,7 @@ gotItemUtf8 { pathSegments, text } model =
                 Sidebar.EditPlaintext _ ->
                     { text = text
                     , originalText = text
+                    , isSaving = False
                     }
                         |> Just
                         |> Sidebar.EditPlaintext

--- a/tailwind.js
+++ b/tailwind.js
@@ -81,6 +81,7 @@ export default {
 
       boxShadow: {
         "inner-outline": "inset 0 0 0 2px rgba(100, 70, 250, .2)",
+        "outline": "0 0 0 2px rgba(100, 70, 250, 0.4)",
       },
 
     },

--- a/tailwind.js
+++ b/tailwind.js
@@ -80,8 +80,8 @@ export default {
       },
 
       boxShadow: {
-        "inner-outline": "inset 0 0 0 2px rgba(100, 70, 250, .2)",
-        "outline": "0 0 0 2px rgba(100, 70, 250, 0.4)",
+        "inner-outline": "inset 0 0 0 2px rgba(100, 70, 250, .2)", // purple 20%
+        "outline": "0 0 0 2px rgba(100, 70, 250, 0.4)", // purple 40%
       },
 
     },
@@ -95,12 +95,13 @@ export default {
 
   variants: {
 
-    backgroundColor: [ "group-hover", "responsive" ],
+    backgroundColor: [ "group-hover", "disabled", "responsive" ],
     borderColor: [ "first", "focus", "group-hover", "hover", "last", "responsive" ],
     borderWidth: [ "first", "last" ],
     margin: [ "first", "last", "responsive" ],
     opacity: [ "group-hover", "responsive" ],
     pointerEvents: [ "group-hover" ],
+    textColor: [ "disabled", "responsive" ],
 
   },
 


### PR DESCRIPTION
Addressing some plaintext editor feedback:

* [X] "First thing is that if I'm inside the HTML file and hit "tab", it highlights the cancel button."
  
  I tried to "shift the HTML around so it tabs to 'save' first and then change the order visually with flexbox", but I didn't like that the visual order didn't match the tab-order. That felt confusing (check out 91bd86a). So I basically mirrored the editor's footer.
* [x] "I think that the Save / Cancel buttons should appear on click, not on first edit"
* [x] "As a user, I think saving is too unreal. We probably want a spinner and a success message or something to convince the user that yes, this IS actually saving"

Also bringing in an idea of my own: When focusing the editor, `Ctrl + S` will save the file.