### PR TITLE
Rework sidebar: more consistent UX, only have one sidebar open at a time.

### DIFF
--- a/src/Application/Common/View/Footer.elm
+++ b/src/Application/Common/View/Footer.elm
@@ -163,7 +163,12 @@ addCreateAction : Model -> Html Msg
 addCreateAction model =
     let
         isInAddOrCreateMode =
-            Maybe.isJust model.addOrCreate
+            case model.sidebar of
+                Just (Drive.Sidebar.AddOrCreate _) ->
+                    True
+                
+                _ ->
+                    False
     in
     action
         Button

--- a/src/Application/Drive/Sidebar.elm
+++ b/src/Application/Drive/Sidebar.elm
@@ -20,6 +20,7 @@ type Model
         -- Nothing means Loading
         , editor : Maybe EditorModel
         }
+    | AddOrCreate AddOrCreateModel
 
 
 type alias EditorModel =

--- a/src/Application/Drive/Sidebar.elm
+++ b/src/Application/Drive/Sidebar.elm
@@ -9,16 +9,17 @@ type Msg
     | DetailsShowPreviewOverlay
 
 
-type alias Model =
-    { path : String
-    , mode : Mode
-    }
+type Model
+    = Details
+        { path : String
+        , showPreviewOverlay : Bool
+        }
+    | EditPlaintext
+        { path : String
 
-
-type Mode
-    = Details { showPreviewOverlay : Bool }
-      -- Nothing means Loading
-    | EditPlaintext (Maybe EditorModel)
+        -- Nothing means Loading
+        , editor : Maybe EditorModel
+        }
 
 
 type alias EditorModel =
@@ -37,9 +38,9 @@ type alias AddOrCreateModel =
 -- 🌱
 
 
-details : Mode
-details =
-    Details { showPreviewOverlay = False }
+details : String -> Model
+details path =
+    Details { path = path, showPreviewOverlay = False }
 
 
 addOrCreate : AddOrCreateModel

--- a/src/Application/Drive/State.elm
+++ b/src/Application/Drive/State.elm
@@ -8,7 +8,7 @@ import Debouncing
 import Dict
 import Drive.Item as Item exposing (Item, Kind(..))
 import Drive.Modals
-import Drive.Sidebar exposing (Mode(..))
+import Drive.Sidebar
 import Drive.State.Sidebar
 import File
 import File.Download
@@ -70,7 +70,7 @@ closeSidebar model =
             }
                 |> (case model.sidebar of
                         Just sidebar ->
-                            case sidebar.mode of
+                            case sidebar of
                                 Drive.Sidebar.Details _ ->
                                     if Common.isSingleFileView model then
                                         goUpOneLevel
@@ -366,11 +366,11 @@ select item model =
                 { model
                     | selectedPath = Just item.path
                     , sidebar =
-                        Just
-                            { path = item.path
-                            , mode =
-                                Drive.Sidebar.EditPlaintext Nothing
-                            }
+                        { path = item.path
+                        , editor = Nothing
+                        }
+                            |> Drive.Sidebar.EditPlaintext
+                            |> Just
                 }
 
     else
@@ -378,10 +378,9 @@ select item model =
             { model
                 | selectedPath = Just item.path
                 , sidebar =
-                    Just
-                        { path = item.path
-                        , mode = Drive.Sidebar.details
-                        }
+                    item.path
+                        |> Drive.Sidebar.details
+                        |> Just
             }
 
 

--- a/src/Application/Drive/View.elm
+++ b/src/Application/Drive/View.elm
@@ -641,7 +641,12 @@ empty model =
             Maybe.isJust model.authenticated
 
         hideContent =
-            Maybe.isJust model.addOrCreate
+            case model.sidebar of
+                Just (Sidebar.AddOrCreate _) ->
+                    True
+
+                _ ->
+                    False
     in
     Html.div
         [ if isAuthenticated then
@@ -973,4 +978,3 @@ listItem isGroundFloor selectedPath ({ kind, loading, name, nameProperties, path
 sidebarOpen : Model -> Bool
 sidebarOpen model =
     Maybe.isJust model.sidebar
-        || Maybe.isJust model.addOrCreate

--- a/src/Application/Drive/View/Sidebar.elm
+++ b/src/Application/Drive/View/Sidebar.elm
@@ -49,11 +49,11 @@ view model =
                         { scrollable = False
                         , expanded = model.sidebarExpanded
                         , body =
-                            case sidebar.mode of
+                            case sidebar of
                                 Sidebar.Details details ->
                                     detailsForSelection details sidebar model
 
-                                Sidebar.EditPlaintext editor ->
+                                Sidebar.EditPlaintext { editor } ->
                                     plaintextEditor editor sidebar model
                         }
 
@@ -539,7 +539,7 @@ addOrCreateForm addOrCreateModel model =
 -- DETAILS
 
 
-detailsForSelection : { showPreviewOverlay : Bool } -> Sidebar.Model -> Model -> Html Msg
+detailsForSelection : { path : String, showPreviewOverlay : Bool } -> Sidebar.Model -> Model -> Html Msg
 detailsForSelection { showPreviewOverlay } sidebar model =
     Html.div
         [ T.flex

--- a/src/Application/Drive/View/Sidebar.elm
+++ b/src/Application/Drive/View/Sidebar.elm
@@ -34,31 +34,30 @@ import Url.Builder
 
 view : Model -> Html Msg
 view model =
-    case model.addOrCreate of
-        Just addOrCreateModel ->
+    case model.sidebar of
+        Just (Sidebar.AddOrCreate addOrCreateModel) ->
             viewSidebar
                 { scrollable = True
                 , expanded = model.sidebarExpanded
                 , body = addOrCreate addOrCreateModel model
                 }
 
+        Just (Sidebar.Details details) ->
+            viewSidebar
+                { scrollable = False
+                , expanded = model.sidebarExpanded
+                , body = detailsForSelection details model
+                }
+
+        Just (Sidebar.EditPlaintext { editor }) ->
+            viewSidebar
+                { scrollable = False
+                , expanded = model.sidebarExpanded
+                , body = plaintextEditor editor model
+                }
+
         Nothing ->
-            case model.sidebar of
-                Just sidebar ->
-                    viewSidebar
-                        { scrollable = False
-                        , expanded = model.sidebarExpanded
-                        , body =
-                            case sidebar of
-                                Sidebar.Details details ->
-                                    detailsForSelection details sidebar model
-
-                                Sidebar.EditPlaintext { editor } ->
-                                    plaintextEditor editor sidebar model
-                        }
-
-                _ ->
-                    nothing
+            nothing
 
 
 {-| NOTE: This is positioned using `position: sticky` and using fixed px values. Kind of a hack, and should be done in a better way, but I haven't found one.
@@ -100,8 +99,8 @@ viewSidebar { scrollable, expanded, body } =
         [ body ]
 
 
-plaintextEditor : Maybe Sidebar.EditorModel -> Sidebar.Model -> Model -> Html Msg
-plaintextEditor maybeEditor sidebar model =
+plaintextEditor : Maybe Sidebar.EditorModel -> Model -> Html Msg
+plaintextEditor maybeEditor model =
     Html.div
         [ T.flex
         , T.flex_col
@@ -539,8 +538,8 @@ addOrCreateForm addOrCreateModel model =
 -- DETAILS
 
 
-detailsForSelection : { path : String, showPreviewOverlay : Bool } -> Sidebar.Model -> Model -> Html Msg
-detailsForSelection { showPreviewOverlay } sidebar model =
+detailsForSelection : { path : String, showPreviewOverlay : Bool } -> Model -> Html Msg
+detailsForSelection { showPreviewOverlay } model =
     Html.div
         [ T.flex
         , T.flex_col

--- a/src/Application/Radix.elm
+++ b/src/Application/Radix.elm
@@ -76,7 +76,6 @@ type alias Model =
     -----------------------------------------
     , sidebarExpanded : Bool
     , sidebar : Maybe Drive.Sidebar.Model
-    , addOrCreate : Maybe Drive.Sidebar.AddOrCreateModel
     }
 
 

--- a/src/Application/State.elm
+++ b/src/Application/State.elm
@@ -81,7 +81,6 @@ init flags url navKey =
       ----------
       , sidebarExpanded = False
       , sidebar = Nothing
-      , addOrCreate = Nothing
       }
       -----------------------------------------
       -- Command


### PR DESCRIPTION
Work on #98.

This was pretty quick to just spin up, so I went ahead. No expectation of this getting merged, but I think this'd move in the right direction.

After this PR, closing the sidebar will always leave the user with a sidebar-less screen.