### PR TITLE
Fix destination directory for creating new private files

### DIFF
--- a/src/Application/Drive/State.elm
+++ b/src/Application/Drive/State.elm
@@ -166,6 +166,14 @@ createFileOrFolder option model =
                     (\fileName ->
                         model.route
                             |> Routing.treePathSegments
+                            |> (\path ->
+                                    case path of
+                                        "public" :: rest ->
+                                            "public" :: rest
+
+                                        _ ->
+                                            "private" :: path
+                               )
                             |> List.add [ fileName ]
                             |> (\p ->
                                     FileSystem.Actions.writeUtf8

--- a/src/Application/FileSystem/Actions.elm
+++ b/src/Application/FileSystem/Actions.elm
@@ -166,4 +166,4 @@ splitPath path =
             { base = Wnfs.Private, path = rest }
 
         _ ->
-            { base = appData, path = path }
+            { base = Wnfs.Private, path = path }


### PR DESCRIPTION
Before, when you tried to add a new file in a private directory, it'd get created at `Apps/Fission/Drive/<path to your file>` instead of at `<path to your file>`.

I feel like creating an encapsulated `Path` module would prevent such problems in the future. `List String` seems to carry too little type information.