### PR TITLE
Alpha SDK for CLI linking

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "dependencies": {
     "fission-kit": "fission-suite/kit#768a1384450d0be543152f75d02ffe3dfe90bd4e",
-    "webnative": "0.23.2",
+    "webnative": "0.24.0-alpha-8",
     "webnative-elm": "^4.0.0-3"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 dependencies:
   fission-kit: github.com/fission-suite/kit/768a1384450d0be543152f75d02ffe3dfe90bd4e
-  webnative: 0.23.2
-  webnative-elm: 4.0.0-3_webnative@0.23.2
+  webnative: 0.24.0-alpha-8
+  webnative-elm: 4.0.0-3_webnative@0.24.0-alpha-8
 devDependencies:
   elm-git-install: 0.1.3
   elm-impfix: 1.0.8
@@ -4066,6 +4066,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==
+  /noble-ed25519/1.2.1:
+    dev: false
+    resolution:
+      integrity: sha512-5ZoYpKxQtyQHVk8GHsAr1BsM91ogFuuIsJkKM116t4PxqJRZrBkg1i33wUu852Minr9+CDR8jqPRrhQ/l+msbQ==
   /node-addon-api/2.0.2:
     dev: false
     resolution:
@@ -5801,15 +5805,15 @@ packages:
     dev: true
     resolution:
       integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
-  /webnative-elm/4.0.0-3_webnative@0.23.2:
+  /webnative-elm/4.0.0-3_webnative@0.24.0-alpha-8:
     dependencies:
-      webnative: 0.23.2
+      webnative: 0.24.0-alpha-8
     dev: false
     peerDependencies:
       webnative: '> 0.0.0'
     resolution:
       integrity: sha512-74y9J2Vj1XEO078GAJEohqroJmJQMyZDbB8MouHEpscLiTxlOstgqlW5JyHNSQ9y2LAVv9Il/lG48QtI4a6LVg==
-  /webnative/0.23.2:
+  /webnative/0.24.0-alpha-8:
     dependencies:
       base58-universal: 1.0.0
       borc: 2.1.2
@@ -5822,12 +5826,13 @@ packages:
       keystore-idb: 0.14.0
       localforage: 1.9.0
       make-error: 1.3.6
+      noble-ed25519: 1.2.1
       throttle-debounce: 2.3.0
     dev: false
     engines:
       node: '>=10.21.0'
     resolution:
-      integrity: sha512-PHd0p41C7AWGpcf95oDLA41qG2nO4zythePT+C3ymQh2j0gsVN6HsQme0puPjK9g/PYAZaaoeC538T33yvDTWQ==
+      integrity: sha512-b+mQfCBZCQGVeC/4U0VT5A5DJ3Num21L322icjlra5U0s6/csx0Wu4Z8yNs83JaZSCtS3nTI86InwGc0AcOERg==
   /whatwg-url/7.1.0:
     dependencies:
       lodash.sortby: 4.7.0
@@ -6117,7 +6122,7 @@ specifiers:
   postcss-import: ^13.0.0
   tailwindcss: ^1.9.6
   terser-dir: ^1.0.7
-  webnative: 0.23.2
+  webnative: 0.24.0-alpha-8
   webnative-elm: ^4.0.0-3
   workbox-cli: ^6.1.2
   workbox-strategies: ^6.1.2

--- a/src/Javascript/index.js
+++ b/src/Javascript/index.js
@@ -48,8 +48,8 @@ const PERMISSIONS = {
   },
 
   fs: {
-    privatePaths: [ "/" ],
-    publicPaths: [ "/" ]
+    private: { directories: [ "/" ] },
+    public: { directories: [ "/" ] }
   }
 }
 


### PR DESCRIPTION
Update Drive to the alpha version of the SDK, so we can use accounts that were linked through the CLI.