### PR TITLE
Run production builds for main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
         run: nix-shell --run "just install-deps"
         
       - name: Build
-        run: nix-shell --run "just staging-build"
+        run: nix-shell --run "just production-build"
         
       - name: Publish to Fission
         uses: fission-suite/publish-action@v1


### PR DESCRIPTION
This is a one liner to properly build production for main. Fixes #139 