### PR TITLE
Add rosetta nix override

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "af958e8057f345ee1aca714c1247ef3ba1c15f5e",
-        "sha256": "1qjavxabbrsh73yck5dcq8jggvh3r2jkbr6b5nlz5d9yrqm9255n",
+        "rev": "e0ca65c81a2d7a4d82a189f1e23a48d59ad42070",
+        "sha256": "1pq9nh1d8nn3xvbdny8fafzw87mj7gsmp6pxkdl65w2g18rmcmzx",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/af958e8057f345ee1aca714c1247ef3ba1c15f5e.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/e0ca65c81a2d7a4d82a189f1e23a48d59ad42070.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
@@ -17,10 +17,10 @@
         "homepage": null,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "90cec09c3642b9be6699015a35e404ecb503aa0d",
-        "sha256": "0134xglcwrq8wp4mnxn6byww9pf2iipxghwpm92bdyknf79msdv1",
+        "rev": "068984c00e0d4e54b6684d98f6ac47c92dcb642e",
+        "sha256": "00j4xv4lhhqwry7jd67brnws4pwb8vn660n43pvxpkalbpxszwfg",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/90cec09c3642b9be6699015a35e404ecb503aa0d.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/068984c00e0d4e54b6684d98f6ac47c92dcb642e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,35 +1,37 @@
-let
+{ rosetta ? false }:
+  let
+    overrides = if rosetta then { system = "x86_64-darwin"; } else {};
 
-  sources = import ./nix/sources.nix;
-  pkgs    = import sources.nixpkgs {};
+    sources = import ./nix/sources.nix;
+    pkgs    = import sources.nixpkgs overrides;
 
-  commands = import ./nix/commands.nix;
-  tasks = commands {pkgs = pkgs;};
+    commands = import ./nix/commands.nix;
+    tasks = commands {pkgs = pkgs;};
 
-  deps = {
-    tools = [
-      pkgs.curl
-      pkgs.devd
-      pkgs.just
-      pkgs.watchexec
-    ];
+    deps = {
+      tools = [
+        pkgs.curl
+        pkgs.devd
+        pkgs.just
+        pkgs.watchexec
+      ];
 
-    elm = [
-      pkgs.elmPackages.elm
-      pkgs.elmPackages.elm-format
-      pkgs.elmPackages.elm-live
-    ];
+      elm = [
+        pkgs.elmPackages.elm
+        pkgs.elmPackages.elm-format
+        pkgs.elmPackages.elm-live
+      ];
 
-    node = [
-      pkgs.nodejs-14_x
-      pkgs.nodePackages.pnpm
-    ];
+      node = [
+        pkgs.nodejs-14_x
+        pkgs.nodePackages.pnpm
+      ];
 
-    fun = [
-      pkgs.figlet
-      pkgs.lolcat
-    ];
-  };
+      fun = [
+        pkgs.figlet
+        pkgs.lolcat
+      ];
+    };
 
 in
 

--- a/shell.nix
+++ b/shell.nix
@@ -14,6 +14,7 @@
         pkgs.devd
         pkgs.just
         pkgs.watchexec
+        pkgs.niv
       ];
 
       elm = [


### PR DESCRIPTION
## Summary

This PR fixes/implements the following **bugs/features**

* [x] Add nix compatibility for M1 macs

The nix shell will not build on machines with the `aarch64` architecture. This change lets us override and use `x86_64`.

## Test plan (required)

On an M1 mac, set up the nix with

```
nix-shell --arg rosetta true
```

Note that your `/etc/nix/nix.conf` will need to contain this line:

```
extra-platforms = x86_64-darwin
```


## After Merge
* [ ] Does this change invalidate any docs or tutorials? No.
* [ ] Does this change require a release to be made? No.

